### PR TITLE
Enable bucket encryption

### DIFF
--- a/src/cfn/template.yaml
+++ b/src/cfn/template.yaml
@@ -100,6 +100,10 @@ Resources:
     Properties:
       VersioningConfiguration:
         Status: Enabled
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
       CorsConfiguration:
         CorsRules:
           - AllowedHeaders: ["*"]


### PR DESCRIPTION
*Description of changes:*
This PR enables `WebUIBucket` bucket encryption.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
